### PR TITLE
feat: add Quarkus form login

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This React application provides a minimal interface for testing WebSocket endpoints.
 It is built with [Vite](https://vite.dev/) and [Material UI](https://mui.com/).
 
+It also includes a simple login form compatible with [Quarkus form-based authentication](https://quarkus.io/guides/security-authentication-mechanisms#form-auth). Users must authenticate before accessing the WebSocket tester.
+
 ## Getting Started
 
 ```bash

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,13 +9,25 @@ import {
   ListItemText,
   Typography,
 } from '@mui/material';
+import LoginForm from './LoginForm.jsx';
 
 export default function App() {
   const [url, setUrl] = useState('ws://localhost:8080/ws');
   const [connected, setConnected] = useState(false);
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
+  const [authenticated, setAuthenticated] = useState(false);
   const wsRef = useRef(null);
+
+  const handleLogin = () => setAuthenticated(true);
+  const handleLogout = async () => {
+    try {
+      await fetch('/logout', { method: 'POST' });
+    } catch {
+      // ignore
+    }
+    setAuthenticated(false);
+  };
 
   const connect = () => {
     const ws = new WebSocket(url);
@@ -42,12 +54,25 @@ export default function App() {
     return () => wsRef.current?.close();
   }, []);
 
+  if (!authenticated) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 4 }}>
+        <LoginForm onLogin={handleLogin} />
+      </Container>
+    );
+  }
+
   return (
     <Container maxWidth="sm" sx={{ py: 4 }}>
       <Stack spacing={2}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          WebSocket Tester
-        </Typography>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h4" component="h1" gutterBottom>
+            WebSocket Tester
+          </Typography>
+          <Button variant="outlined" onClick={handleLogout}>
+            Logout
+          </Button>
+        </Stack>
 
         <Stack direction="row" spacing={1}>
           <TextField

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Stack, TextField, Button, Typography } from '@mui/material';
+
+export default function LoginForm({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    const formData = new URLSearchParams();
+    formData.append('j_username', username);
+    formData.append('j_password', password);
+
+    try {
+      const response = await fetch('/j_security_check', {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+      if (response.ok) {
+        onLogin();
+      } else {
+        setError('Login failed');
+      }
+    } catch (e) {
+      setError(e.message || 'Network error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={2}>
+        <Typography variant="h5">Login</Typography>
+        <TextField
+          label="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <TextField
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button type="submit" variant="contained">
+          Login
+        </Button>
+      </Stack>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add LoginForm component that posts j_username and j_password to `/j_security_check`
- gate WebSocket tester behind login and allow logging out
- document authentication requirement in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b61b2a04832c82d4e5f46f82fd41