### PR TITLE
feat: allow configuring backend address

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ npm run dev
 ```
 
 The app opens in development mode. Enter your WebSocket endpoint, connect, and start sending messages.
+
+## Configuration
+
+Set the backend address by defining a `VITE_BACKEND_URL` environment variable. The value should be the base URL (e.g. `http://backend:8080`). It is used for login requests and as the default WebSocket endpoint (`ws://backend:8080/ws`).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,9 +10,10 @@ import {
   Typography,
 } from '@mui/material';
 import LoginForm from './LoginForm.jsx';
+import { WS_URL, LOGOUT_URL } from './config.js';
 
 export default function App() {
-  const [url, setUrl] = useState('ws://localhost:8080/ws');
+  const [url, setUrl] = useState(WS_URL);
   const [connected, setConnected] = useState(false);
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
@@ -22,7 +23,7 @@ export default function App() {
   const handleLogin = () => setAuthenticated(true);
   const handleLogout = async () => {
     try {
-      await fetch('/logout', { method: 'POST' });
+      await fetch(LOGOUT_URL, { method: 'POST' });
     } catch {
       // ignore
     }

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Stack, TextField, Button, Typography } from '@mui/material';
+import { LOGIN_URL } from './config.js';
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState('');
@@ -14,7 +15,7 @@ export default function LoginForm({ onLogin }) {
     formData.append('j_password', password);
 
     try {
-      const response = await fetch('/j_security_check', {
+      const response = await fetch(LOGIN_URL, {
         method: 'POST',
         body: formData,
         headers: {

--- a/src/LoginForm.test.jsx
+++ b/src/LoginForm.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import LoginForm from './LoginForm.jsx';
+import { LOGIN_URL } from './config.js';
 
 describe('LoginForm', () => {
   afterEach(() => {
@@ -17,7 +18,7 @@ describe('LoginForm', () => {
     await userEvent.type(screen.getByLabelText(/password/i), 'pass');
     await userEvent.click(screen.getByRole('button', { name: /login/i }));
 
-    expect(fetch).toHaveBeenCalledWith('/j_security_check', expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith(LOGIN_URL, expect.any(Object));
     expect(onLogin).toHaveBeenCalled();
   });
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,5 @@
+const rawBackend = import.meta.env.VITE_BACKEND_URL || window.location.origin;
+export const BACKEND_URL = rawBackend.endsWith('/') ? rawBackend.slice(0, -1) : rawBackend;
+export const WS_URL = `${BACKEND_URL.replace(/^http/, 'ws')}/ws`;
+export const LOGIN_URL = `${BACKEND_URL}/j_security_check`;
+export const LOGOUT_URL = `${BACKEND_URL}/logout`;


### PR DESCRIPTION
## Summary
- allow setting backend base URL via `VITE_BACKEND_URL`
- derive WebSocket and auth endpoints from backend URL
- document backend URL configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bd5dd314832c9e716a1be8a1b7ae